### PR TITLE
Fix ReferenceError in `reactionrole` command

### DIFF
--- a/commands/reactionrole.js
+++ b/commands/reactionrole.js
@@ -39,17 +39,13 @@ module.exports = {
             } else {
                 return;
             }
-
         });
 
         client.on('messageReactionRemove', async (reaction, user) => {
-            c
-
             if (reaction.message.partial) await reaction.message.fetch();
             if (reaction.partial) await reaction.fetch();
             if (user.bot) return;
             if (!reaction.message.guild) return;
-
 
             if (reaction.message.channel.id == channel) {
                 if (reaction.emoji.name === roleOneEmoji) {


### PR DESCRIPTION
A character left behind caused `reactionrole` to error out when removing a reaction, this PR solves this issue by removing the error-causing reference. 🙂