### PR TITLE
Fix ReferenceError in `reactionrole` command.

### DIFF
--- a/commands/Misc./reactionrole.js
+++ b/commands/Misc./reactionrole.js
@@ -39,17 +39,13 @@ module.exports = {
             } else {
                 return;
             }
-
         });
 
         client.on('messageReactionRemove', async (reaction, user) => {
-            c
-
             if (reaction.message.partial) await reaction.message.fetch();
             if (reaction.partial) await reaction.fetch();
             if (user.bot) return;
             if (!reaction.message.guild) return;
-
 
             if (reaction.message.channel.id == channel) {
                 if (reaction.emoji.name === roleOneEmoji) {
@@ -63,5 +59,4 @@ module.exports = {
             }
         });
     }
-
 }


### PR DESCRIPTION
This PR fixes the ReferenceError thrown by the `reactionrole` command when removing a reaction.