### PR TITLE
Fix commands not checking roles correctly.

### DIFF
--- a/commands/Examples/Admin.js
+++ b/commands/Examples/Admin.js
@@ -3,10 +3,10 @@
 module.exports = {
     name: 'admin',
     description: "admin example",
-    execute(message, args, Discord) {
+    execute({ message, roles }) {
 
         //All code to be exixuted with correct permisions goes inside this if.
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+        if (message.member.roles.cache.has(roles.admin)) {
             message.channel.send('This is an admin command example');
 
             //The resricted reponse message goes in here.

--- a/commands/Misc./reactionrole.js
+++ b/commands/Misc./reactionrole.js
@@ -4,7 +4,7 @@
 module.exports = {
     name: 'reactionrole',
     description: "Sets up a reaction role message!",
-    async execute(message, args, Discord, client) {
+    async execute({ message, Discord, client }) {
         const channel = '825873304854331393';
         const roleOne = message.guild.roles.cache.get(RR_ROLE_1_ID);
         const roleTwo = message.guild.roles.cache.get(RR_ROLE_2_ID);

--- a/commands/Moderation/ban.js
+++ b/commands/Moderation/ban.js
@@ -4,7 +4,7 @@
 module.exports = {
     name: 'ban',
     description: "bans users",
-    execute(message, args, Discord) {
+    execute({ message }) {
         const member = message.mentions.users.first();
 
         if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {

--- a/commands/Moderation/clear.js
+++ b/commands/Moderation/clear.js
@@ -5,8 +5,8 @@
 module.exports = {
     name: 'clear',
     description: "clears messages",
-    async execute(message, args, Discord) {
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+    async execute({ message, args, roles }) {
+        if (message.member.roles.cache.has(roles.admin)) {
             if (!args[0]) return message.reply("Please specify a number of messages to clear.")
             if (isNaN(args[0])) return message.reply("Please enter a number instead of text.")
 

--- a/commands/Moderation/kick.js
+++ b/commands/Moderation/kick.js
@@ -4,10 +4,10 @@
 module.exports = {
     name: 'kick',
     description: "kicks users",
-    execute(message, args, Discord) {
+    execute({ message, roles }) {
         const member = message.mentions.users.first();
 
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+        if (message.member.roles.cache.has(roles.admin)) {
             if (member) {
                 const memberTarget = message.guild.members.cache.get(member.id)
                 memberTarget.kick()

--- a/commands/Moderation/mute.js
+++ b/commands/Moderation/mute.js
@@ -7,15 +7,15 @@ const ms = require('ms');
 module.exports = {
     name: 'mute',
     description: "mutes user",
-    execute(message, args, Discord) {
+    execute({ message, args, roles }) {
 
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+        if (message.member.roles.cache.has(roles.admin)) {
 
             const target = message.mentions.users.first();
             if (target) {
 
-                let mainRole = message.guild.roles.cache.get(USER_ROLE_ID);
-                let muteRole = message.guild.roles.cache.get(MUTED_ROLE_ID);
+                let mainRole = message.guild.roles.cache.get(roles.users);
+                let muteRole = message.guild.roles.cache.get(roles.muted);
 
                 let memberTarget = message.guild.members.cache.get(target.id);
 

--- a/commands/Moderation/unmute.js
+++ b/commands/Moderation/unmute.js
@@ -5,14 +5,14 @@ const ms = require('ms');
 module.exports = {
     name: 'unmute',
     description: "unmutes user",
-    execute(message, args, Discord) {
+    execute({ message, roles }) {
 
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+        if (message.member.roles.cache.has(roles.admin)) {
 
             const target = message.mentions.users.first();
             if (target) {
-                let mainRole = message.guild.roles.cache.get(USER_ROLE_ID);
-                let muteRole = message.guild.roles.cache.get(MUTED_ROLE_ID);
+                let mainRole = message.guild.roles.cache.get(roles.users);
+                let muteRole = message.guild.roles.cache.get(roles.muted);
 
                 let memberTarget = message.guild.members.cache.get(target.id);
 

--- a/commands/Moderation/wipe.js
+++ b/commands/Moderation/wipe.js
@@ -5,8 +5,8 @@
 module.exports = {
     name: 'wipe',
     description: "clear with bigger options",
-    async execute(message, args, Discord) {
-        if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {
+    async execute({ message, args, roles }) {
+        if (message.member.roles.cache.has(roles.admin)) {
             if (!args[0]) return message.reply("Please specify a number of messages to clear.")
             if (isNaN(args[0])) return message.reply("Please enter a number instead of text.")
 

--- a/commands/Resources/invite.js
+++ b/commands/Resources/invite.js
@@ -3,7 +3,7 @@
 module.exports = {
     name: 'invite',
     description: "sends the bot invite link",
-    execute(message, args, Discord) {
+    execute({ message }) {
         message.channel.send('You can invite Heptagram to your server at https://discord.com/oauth2/authorize?client_id=783073095036043274&permissions=8&scope=bot');
     }
 }

--- a/commands/Resources/support.js
+++ b/commands/Resources/support.js
@@ -3,7 +3,7 @@
 module.exports = {
     name: 'support',
     description: "sends a link for the bot support server",
-    execute(message, args, Discord) {
+    execute({ message }) {
 
         //All code to be exixuted with correct permisions goes inside this if.
         if (message.member.roles.cache.has(ADMIN_ROLE_ID)) {

--- a/commands/Utilitys/ping.js
+++ b/commands/Utilitys/ping.js
@@ -4,7 +4,7 @@
 module.exports = {
     name: 'ping',
     description: "this is a ping command!",
-    execute(message, args, Discord) {
+    execute({ message }) {
         message.channel.send('pong!');
     }
 }

--- a/example-config.json
+++ b/example-config.json
@@ -1,5 +1,9 @@
-  
 {
-	"prefix": "!",
-	"token": "your-token-goes-here"
+  "prefix": "!",
+  "token": "your-token-goes-here",
+  "roles": {
+    "admin": "826438768621910000",
+    "users": "826438671993010000",
+    "muted": "826438805686050000"
+  }
 }

--- a/main.js
+++ b/main.js
@@ -6,8 +6,7 @@ const fs = require('fs');
 const Discord = require('discord.js');
 
 const config = require('dotenv').config();
-const { prefix, token } = require('./config.json');
-
+const { prefix, token, roles } = require('./config.json');
 
 const client = new Discord.Client({ partials: ["MESSAGE", "CHANNEL", "REACTION"] });
 const webhookClient = new Discord.WebhookClient(config.webhookID, config.webhookToken);

--- a/main.js
+++ b/main.js
@@ -36,7 +36,7 @@ client.on('message', message => {
 	if (!client.commands.has(command)) return;
 
 	try {
-		client.commands.get(command).execute(message, args);
+		client.commands.get(command).execute({ message, args, Discord, client, roles });
 	} catch (error) {
 		console.error(error);
 		message.reply('there was an error trying to execute that command! Please contact a developer in our support server.');


### PR DESCRIPTION
This PR fixes commands not having access to roles by adding them to the config.

This PR also adds object destructuring to the command execution flow so we can pass and grab what we need when executing a command, e.g if we only need the `message` and `roles`.

```
execute({ message, roles }) {
    if (message.member.roles.cache.has(roles.muted)) {
        message.channel.send('Sorry, this command is for non-muted members!');

        return; 
    }
    
    message.channel.send('Hello non-muted member!');
}
```

Might not be the best design choice, but it works for now. 👍