### PR TITLE
feat: add help command

### DIFF
--- a/commands/Utilitys/help.js
+++ b/commands/Utilitys/help.js
@@ -1,0 +1,47 @@
+const { prefix } = require('../../config.json');
+
+module.exports = {
+    name: 'help',
+    description: 'List all of my commands or info about a specific command.',
+    aliases: ['commands'],
+    usage: ['command-name'],
+    cooldown: 5,
+    execute( {message, args} ) {
+        const data = [];
+        const { commands } = message.client;
+        if (!args) {
+            return message.reply('no arguments present!');
+        }        
+        if (!args.length) {
+            data.push('Here\'s a list of all my commands:');
+            data.push(commands.map(command => command.name).join(', '));
+            data.push(`\nYou can send \`${prefix}help [command name]\` to get info on a specific command!`);
+
+            return message.author.send(data, { split: true })
+                .then(() => {
+                    if (message.channel.type === 'dm') return;
+                    message.reply('I\'ve sent you a DM with all my commands!');
+                })
+                .catch(error => {
+                    console.error(`Could not send help DM to ${message.author.tag}.\n`, error);
+                    message.reply('it seems like I can\'t DM you! Do you have DMs disabled?');
+                });            
+        }
+        const name = args[0].toLowerCase();
+        const command = commands.get(name) || commands.find(c => c.aliases && c.aliases.includes(name));
+
+        if (!command) {
+            return message.reply('that\'s not a valid command!');
+        }
+
+        data.push(`**Name:** ${command.name}`);
+
+        if (command.aliases) data.push(`**Aliases:** ${command.aliases.join(', ')}`);
+        if (command.description) data.push(`**Description:** ${command.description}`);
+        if (command.usage) data.push(`**Usage:** ${prefix}${command.name} ${command.usage}`);
+
+        data.push(`**Cooldown:** ${command.cooldown || 3} second(s)`);
+
+        message.channel.send(data, { split: true });
+    },
+};


### PR DESCRIPTION
Fixes #22 
- Add a help command
- Sends a DM to user when !help is typed
- Gives info about commands when command is passed as argument

Screenshot:
![image](https://user-images.githubusercontent.com/20258660/113589357-4151a180-95ff-11eb-9719-ba36392392b9.png)

Let me know if this is good to go or if there are any changes that need to be made!