### PR TITLE
Lock and Unlock commands on specific role only

### DIFF
--- a/commands/Moderation/lock.js
+++ b/commands/Moderation/lock.js
@@ -2,29 +2,33 @@
 const { prefix, token, roles, MongoDB, serverId, colors } = require('../../config.json');
 
 module.exports = {
-    name: "lock",
-    category: "moderation",
-    description: "Locks a Channel",
-    guildOnly: true,
-    execute: async ({ message, roles, Discord}) => {
-        if (! (message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
-            return message.channel.send("You don't have enough Permissions");
-        }
-
-        message.channel.overwritePermissions([
-            {
-                id: message.guild.id,
-                deny: ['SEND_MESSAGES'],
-            },
-        ]);
-
-        const embed = new Discord.MessageEmbed()
-            .setTitle("Channel Updates")
-            .setDescription(`${message.channel} has been Locked`)
-            .setColor(colors.heptagram);
-
-        await message.channel.send(embed);
-
-        message.delete();
+  name: "lock",
+  category: "moderation",
+  description: "Locks a Channel",
+  guildOnly: true,
+  execute: async ({ message, roles, Discord }) => {
+    if (!(message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
+      return message.channel.send("You don't have enough Permissions");
     }
+
+    const argRole = message.content.split(' ').slice(1);
+    if (!argRole || argRole.length === 0) return message.channel.send({ embed: new Discord.MessageEmbed().setDescription(`You must enter valid role ID's.`) })
+    let role = message.guild.roles.cache.get(argRole[0]);
+
+
+    message.channel.updateOverwrite(role,
+      {
+        SEND_MESSAGES: false
+      },
+    );
+
+    const embed = new Discord.MessageEmbed()
+      .setTitle("Channel Updates")
+      .setDescription(`${message.channel} has been Locked for ${role}`)
+      .setColor(colors.heptagram);
+
+    await message.channel.send(embed);
+
+    message.delete();
+  }
 }

--- a/commands/Moderation/lock.js
+++ b/commands/Moderation/lock.js
@@ -4,16 +4,24 @@ const { prefix, token, roles, MongoDB, serverId, colors } = require('../../confi
 module.exports = {
   name: "lock",
   category: "moderation",
-  description: "Locks a Channel",
+  description: "Locks a Channel for a specific Role.",
   guildOnly: true,
   execute: async ({ message, roles, Discord }) => {
     if (!(message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
       return message.channel.send("You don't have enough Permissions");
     }
 
-    const argRole = message.content.split(' ').slice(1);
+    let argRole
+    if (message.mentions.roles.last()) {
+      argRole = message.mentions.roles.last().id;
+    } else if (/^[0-9]{18}$/i.test(message.content.split(' ').slice(1)[0])) {
+      argRole = message.content.split(' ').slice(1);
+    } else {
+      return message.channel.send("No valid id or mention was Provided!")
+    }
+
     if (!argRole || argRole.length === 0) return message.channel.send({ embed: new Discord.MessageEmbed().setDescription(`You must enter valid role ID's.`) })
-    let role = message.guild.roles.cache.get(argRole[0]);
+    let role = message.guild.roles.cache.get(argRole);
 
 
     message.channel.updateOverwrite(role,

--- a/commands/Moderation/unlock.js
+++ b/commands/Moderation/unlock.js
@@ -7,24 +7,27 @@ module.exports = {
   description: "Unlock a Channel",
   guildOnly: true,
   execute: async ({ message, roles, Discord }) => {
-      if (! (message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
-          return message.channel.send("You don't have enough Permissions");
-      }
+    if (!(message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
+      return message.channel.send("You don't have enough Permissions");
+    }
 
-      message.channel.overwritePermissions([
-          {
-              id: message.guild.id,
-              allow: ['SEND_MESSAGES'],
-          },
-      ]);
+    const argRole = message.content.split(' ').slice(1);
+    if (!argRole || argRole.length === 0) return message.channel.send({ embed: new Discord.MessageEmbed().setDescription(`You must enter valid role ID's.`) })
+    let role = message.guild.roles.cache.get(argRole[0]);
 
-      const embed = new Discord.MessageEmbed()
-          .setTitle("Channel Updates")
-          .setDescription(`${message.channel} has been unlocked`)
-          .setColor(colors.heptagram);
 
-      await message.channel.send(embed);
+    message.channel.updateOverwrite(role,
+      {
+        SEND_MESSAGES: true
+      },
+    );
+    const embed = new Discord.MessageEmbed()
+      .setTitle("Channel Updates")
+      .setDescription(`${message.channel} has been unlocked for ${role}`)
+      .setColor(colors.heptagram);
 
-      message.delete();
+    await message.channel.send(embed);
+
+    message.delete();
   }
 };

--- a/commands/Moderation/unlock.js
+++ b/commands/Moderation/unlock.js
@@ -4,17 +4,24 @@ const { prefix, token, roles, MongoDB, serverId, colors } = require('../../confi
 module.exports = {
   name: "unlock",
   category: "moderation",
-  description: "Unlock a Channel",
+  description: "Unlock a Channel for a specific Role.",
   guildOnly: true,
   execute: async ({ message, roles, Discord }) => {
     if (!(message.member.hasPermission('MANAGE_SERVER', 'MANAGE_CHANNELS') && message.member.roles.cache.has(roles.admin))) {
       return message.channel.send("You don't have enough Permissions");
     }
 
-    const argRole = message.content.split(' ').slice(1);
-    if (!argRole || argRole.length === 0) return message.channel.send({ embed: new Discord.MessageEmbed().setDescription(`You must enter valid role ID's.`) })
-    let role = message.guild.roles.cache.get(argRole[0]);
+    let argRole
+    if (message.mentions.roles.last()) {
+      argRole = message.mentions.roles.last().id;
+    } else if (/^[0-9]{18}$/i.test(message.content.split(' ').slice(1)[0])) {
+      argRole = message.content.split(' ').slice(1);
+    } else {
+      return message.channel.send("No valid id or mention was Provided!")
+    }
 
+    if (!argRole || argRole.length === 0) return message.channel.send({ embed: new Discord.MessageEmbed().setDescription(`You must enter valid role ID's.`) })
+    let role = message.guild.roles.cache.get(argRole);
 
     message.channel.updateOverwrite(role,
       {


### PR DESCRIPTION
I made it so the commands need the ID of the role you want to lock or unlock the channel for and it updates the permissions only for that specific role. Lots of changes appear because Prettier autoformated my code.