### PR TITLE
Unnecessary line

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,6 @@ logger.heptagram(`Starting Heptagram || Version: ${pjson.version}`)
 
 const { Client, Collection } = require('discord.js');
 const { readdirSync } = require("fs");
-const heptahandler = require('heptagram-handler');
 const path = require("path");
 const io = require('@pm2/io');
 


### PR DESCRIPTION
The `package.json` shows that you've removed the heptagram handler, so why keep it in the `main.js`